### PR TITLE
Update 'david-dm' subdomain

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var expressions = [
   /^https?:\/\/img\.shields\.io/,
   /^https?:\/\/(?:(?:www|api|secure)\.)?travis-ci\.org\/.*\.(?:svg|png)(?:\?|$)/,
-  /^https?:\/\/status\.david-dm\.org(?:\/.+){2}\.(?:svg|png)(?:\?|$)/,
+  /^https?:\/\/status\.david-dm\.org(?:\/.+){2}\.(?:svg|png)/,
   /^https?:\/\/(?:www\.)?nodei\.co(?:\/.+){2}\.(?:svg|png)(?:\?|$)/,
   /^https?:\/\/inch-ci\.org(?:\/.+){3}\.(?:svg|png)(?:\?|$)/,
   /^https?:\/\/badge\.fury\.io(?:\/[^/]+){2}\.(?:svg|png)(?:\?|$)/,

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var expressions = [
   /^https?:\/\/img\.shields\.io/,
   /^https?:\/\/(?:(?:www|api|secure)\.)?travis-ci\.org\/.*\.(?:svg|png)(?:\?|$)/,
-  /^https?:\/\/(?:www\.)?david-dm\.org(?:\/.+){2}\.(?:svg|png)/,
+  /^https?:\/\/(?:status\.)?david-dm\.org(?:\/.+){2}\.(?:svg|png)(?:\?|$)/,
   /^https?:\/\/(?:www\.)?nodei\.co(?:\/.+){2}\.(?:svg|png)(?:\?|$)/,
   /^https?:\/\/inch-ci\.org(?:\/.+){3}\.(?:svg|png)(?:\?|$)/,
   /^https?:\/\/badge\.fury\.io(?:\/[^/]+){2}\.(?:svg|png)(?:\?|$)/,

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var expressions = [
   /^https?:\/\/img\.shields\.io/,
   /^https?:\/\/(?:(?:www|api|secure)\.)?travis-ci\.org\/.*\.(?:svg|png)(?:\?|$)/,
-  /^https?:\/\/(?:status\.)?david-dm\.org(?:\/.+){2}\.(?:svg|png)(?:\?|$)/,
+  /^https?:\/\/status\.david-dm\.org(?:\/.+){2}\.(?:svg|png)(?:\?|$)/,
   /^https?:\/\/(?:www\.)?nodei\.co(?:\/.+){2}\.(?:svg|png)(?:\?|$)/,
   /^https?:\/\/inch-ci\.org(?:\/.+){3}\.(?:svg|png)(?:\?|$)/,
   /^https?:\/\/badge\.fury\.io(?:\/[^/]+){2}\.(?:svg|png)(?:\?|$)/,

--- a/test.js
+++ b/test.js
@@ -87,19 +87,23 @@ test('isBadge(url)', function (t) {
 
   t.test('david-dm', function (st) {
     st.equal(
-      isBadge('https://david-dm.org/strongloop/express.svg?style=flat'),
+      isBadge('https://status.david-dm.org/strongloop/express.svg?style=flat'),
       true,
       'ok: flat'
     )
 
     st.equal(
-      isBadge('https://david-dm.org/strongloop/express.svg?style=flat-square'),
+      isBadge(
+        'https://status.david-dm.org/strongloop/express.svg?style=flat-square'
+      ),
       true,
       'ok: flat-square'
     )
 
     st.equal(
-      isBadge('https://david-dm.org/strongloop/express.svg?style=flat-square'),
+      isBadge(
+        'https://status.david-dm.org/strongloop/express.svg?style=flat-square'
+      ),
       true,
       'not ok: w/o extension'
     )


### PR DESCRIPTION
https://david-dm.org `www` optional subdomain has been replaced by mandatory `status`:

- `status` subdomain is mandatory:
  - `https://david-dm.org/gh/bower/bower.svg` -> ![](https://david-dm.org/gh/bower/bower.svg)
  - `http://david-dm.org/gh/bower/bower.svg` -> ![](https://david-dm.org/gh/bower/bower.svg)
  - `https://www.david-dm.org/bower/bower.svg` -> ![](https://www.david-dm.org/bower/bower.svg)
  - `http://www.david-dm.org/gh/bower/bower.svg` -> ![](https://www.david-dm.org/gh/bower/bower.svg)
  - `https://status.david-dm.org/gh/bower/bower.svg` -> ![](https://status.david-dm.org/gh/bower/bower.svg)
  - `http://status.david-dm.org/gh/bower/bower.svg` -> ![](http://status.david-dm.org/gh/bower/bower.svg)